### PR TITLE
Backoff and retry on HTTP 429 (Too Many Requests).

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiofiles~=0.8.0
 aiohttp~=3.8.1
 attrs==20.3.0
+backoff==2.2.1
 chardet==3.0.4
 dataclass-factory==2.16
 idna==3.1

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setuptools.setup(
     url="https://github.com/dotX12/ShazamIO",
     install_requires=[
         "aiohttp",
+        "backoff",
         "pydub",
         "numpy",
         "aiofiles",

--- a/shazamio/exceptions.py
+++ b/shazamio/exceptions.py
@@ -12,3 +12,7 @@ class BadCountryName(Exception):
 
 class BadMethod(Exception):
     pass
+
+
+class TooManyRequests(Exception):
+    pass


### PR DESCRIPTION
Shazam appears to have started enforcing a rate limit of ~5 requests per minute, after which an HTTP 429 response is returned. Attempting to handle the response results in a `FailedDecodeJson` exception being raised. Instead, backoff and retry the request.