### PR TITLE
Added Proxy option

### DIFF
--- a/examples/proxy.py
+++ b/examples/proxy.py
@@ -1,0 +1,15 @@
+import asyncio
+from shazamio import Shazam, Serialize
+
+async def main():
+    proxy = 'http://your_user:your_password@your_proxy_url:your_proxy_port'
+    shazam = Shazam(proxy=proxy) #All requests will be made with this proxy
+    out = await shazam.recognize_song("data/dora.ogg")
+    print(out)
+
+    serialized = Serialize.full_track(out)
+    print(serialized)
+
+
+loop = asyncio.get_event_loop_policy().get_event_loop()
+loop.run_until_complete(main())

--- a/shazamio/api.py
+++ b/shazamio/api.py
@@ -22,10 +22,11 @@ class Shazam(Converter, Geo, Request):
     """Is asynchronous framework for reverse engineered Shazam API written in Python 3.7 with
     asyncio and aiohttp."""
 
-    def __init__(self, language: str = "en-US", endpoint_country: str = "GB"):
+    def __init__(self, language: str = "en-US", endpoint_country: str = "GB", proxy: str = ""):
         super().__init__(language=language)
         self.language = language
         self.endpoint_country = endpoint_country
+        self.proxy = proxy
 
     async def top_world_tracks(self, limit: int = 200, offset: int = 0) -> Dict[str, Any]:
         """
@@ -47,6 +48,7 @@ class Shazam(Converter, Geo, Request):
                 offset=offset,
             ),
             headers=self.headers(),
+            proxy=self.proxy
         )
 
     async def artist_about(
@@ -75,6 +77,7 @@ class Shazam(Converter, Geo, Request):
             ),
             params=params_dict,
             headers=self.headers(),
+            proxy=self.proxy
         )
 
     async def track_about(self, track_id: int) -> Dict[str, Any]:
@@ -93,6 +96,7 @@ class Shazam(Converter, Geo, Request):
                 track_id=track_id,
             ),
             headers=self.headers(),
+            proxy=self.proxy
         )
 
     async def top_country_tracks(
@@ -123,6 +127,7 @@ class Shazam(Converter, Geo, Request):
                 offset=offset,
             ),
             headers=self.headers(),
+            proxy=self.proxy
         )
 
     async def top_city_tracks(
@@ -157,6 +162,7 @@ class Shazam(Converter, Geo, Request):
                 city_id=city_id,
             ),
             headers=self.headers(),
+            proxy=self.proxy
         )
 
     async def top_world_genre_tracks(
@@ -194,6 +200,7 @@ class Shazam(Converter, Geo, Request):
                 genre=genre,
             ),
             headers=self.headers(),
+            proxy=self.proxy
         )
 
     async def top_country_genre_tracks(
@@ -232,6 +239,7 @@ class Shazam(Converter, Geo, Request):
                 genre=genre,
             ),
             headers=self.headers(),
+            proxy=self.proxy
         )
 
     async def related_tracks(
@@ -262,6 +270,7 @@ class Shazam(Converter, Geo, Request):
                 track_id=track_id,
             ),
             headers=self.headers(),
+            proxy=self.proxy
         )
 
     async def search_artist(
@@ -290,6 +299,7 @@ class Shazam(Converter, Geo, Request):
                 query=query,
             ),
             headers=self.headers(),
+            proxy=self.proxy
         )
 
     async def search_track(self, query: str, limit: int = 10, offset: int = 0) -> Dict[str, Any]:
@@ -313,6 +323,7 @@ class Shazam(Converter, Geo, Request):
                 query=query,
             ),
             headers=self.headers(),
+            proxy=self.proxy
         )
 
     async def listening_counter(self, track_id: int) -> Dict[str, Any]:
@@ -330,6 +341,7 @@ class Shazam(Converter, Geo, Request):
                 language=self.language,
             ),
             headers=self.headers(),
+            proxy=self.proxy
         )
 
     async def get_youtube_data(self, link: str) -> Dict[str, Any]:
@@ -375,4 +387,5 @@ class Shazam(Converter, Geo, Request):
             ),
             headers=self.headers(),
             json=data,
+            proxy=self.proxy
         )


### PR DESCRIPTION
Related to this issue: https://github.com/dotX12/ShazamIO/issues/65

I recently started experiencing issues using the library in a project because I consistently reached the Shazam API call limit. That's why I decided to implement the option to use proxies.

I added the 'proxy' parameter to the Shazam class; hence, all requests will use this proxy. I believe that if someone wants to use proxies, they would prefer using the same proxy for all requests. If you think the proxy should be in the 'recognize_song' call, let me know, and I can make the change.

```python
class Shazam(Converter, Geo, Request):
    """Is asynchronous framework for reverse engineered Shazam API written in Python 3.7 with
    asyncio and aiohttp."""

    def __init__(self, language: str = "en-US", endpoint_country: str = "GB", proxy: str = ""):
        super().__init__(language=language)
        self.language = language
        self.endpoint_country = endpoint_country
        self.proxy = proxy
```