### PR TITLE
Remove GenericModel as it's no longer necessary

### DIFF
--- a/shazamio/schemas/base.py
+++ b/shazamio/schemas/base.py
@@ -3,7 +3,6 @@ from typing import Optional
 from typing import TypeVar
 
 from pydantic import BaseModel
-from pydantic.generics import GenericModel
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -17,22 +16,22 @@ class BaseIdTypeHref(BaseHref):
     type: str
 
 
-class BaseIdTypeHrefAttributesModel(GenericModel, BaseIdTypeHref, Generic[T]):
+class BaseIdTypeHrefAttributesModel(BaseIdTypeHref, Generic[T]):
     attributes: T
 
 
-class BaseAttributesModel(GenericModel, BaseModel, Generic[T]):
+class BaseAttributesModel(BaseModel, Generic[T]):
     attributes: T
 
 
-class BaseDataModel(GenericModel, BaseModel, Generic[T]):
+class BaseDataModel(BaseModel, Generic[T]):
     data: T
 
 
-class BaseHrefNextData(GenericModel, BaseHref, Generic[T]):
+class BaseHrefNextData(BaseHref, Generic[T]):
     next: Optional[str] = None
     data: T
 
 
-class BaseHrefData(GenericModel, BaseHref, Generic[T]):
+class BaseHrefData(BaseHref, Generic[T]):
     data: T


### PR DESCRIPTION
As you can see on the [pydantic docs](https://github.com/pydantic/pydantic/blob/main/docs/migration.md#changes-to-pydanticgenericsgenericmodel), GenericModel has been removed and you can use BaseModel + Generic.