### PR TITLE
Added audioop and ahttp_retry to get shazamio working for py3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 aiofiles==24.1.0
 aiohappyeyeballs==2.4.3
 aiohttp==3.10.10
+aiohttp_retry==2.9.1
 aiosignal==1.3.1
+audioop-lts; python_version >= "3.13"
 annotated-types==0.7.0
 anyio==4.6.2.post1
 async-timeout==4.0.3
@@ -22,7 +24,7 @@ pydantic_core==2.23.4
 pydub==0.25.1
 pytest==8.3.3
 pytest-asyncio==0.24.0
-shazamio_core==1.0.7
+shazamio_core==1.1.2
 sniffio==1.3.1
 tomli==2.0.2
 typing_extensions==4.12.2


### PR DESCRIPTION
Since py3.13, audioop was removed. As a result, shazamio simply doesn't work on projects using newer python versions (e.g. radio-active).

This PR adds audioop, bumps the shazamio-core version, and ahttp_retry. Now it works (except for the about artist test, which currently gets a 405 error - likely to do with some Shazam Api change. Not fixing here.
