### PR TITLE
make pydub optional, only required for deprecated recognize_song

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,19 @@ include = [
 python = "^3.10"
 numpy = "^2.2.2"
 aiohttp = "^3.8.3"
-pydub = "^0.25.1"
 dataclass-factory = "^2.16"
 aiofiles = "^23.2.1"
 anyio = "^4.3.0"
 aiohttp-retry = "^2.8.3"
 pydantic = "^2.9.2"
 shazamio-core = "1.1.2"
+
+[tool.poetry.extras]
+legacy = ["pydub"]
+
+[tool.poetry.dependencies.pydub]
+version = "^0.25.1"
+optional = true
 
 [tool.poetry.group.dev.dependencies]
 black = {version = "^24.2.0", allow-prereleases = true}

--- a/shazamio/api.py
+++ b/shazamio/api.py
@@ -5,7 +5,6 @@ from typing import Dict, Any, Union, List
 from typing import Optional
 
 from aiohttp_retry import ExponentialRetry
-from pydub import AudioSegment
 from shazamio_core import Recognizer, Signature, SearchParams
 
 from .client import HTTPClient
@@ -517,7 +516,7 @@ class Shazam(Request):
     @deprecated("Use recognize method instead of recognize_song")
     async def recognize_song(
         self,
-        data: Union[str, pathlib.Path, bytes, bytearray, AudioSegment],
+        data: Union[str, pathlib.Path, bytes, bytearray],
         proxy: Optional[str] = None,
     ) -> Dict[str, Any]:
         """

--- a/shazamio/converter.py
+++ b/shazamio/converter.py
@@ -1,7 +1,5 @@
 from typing import Any, Dict
 
-from pydub import AudioSegment
-
 from shazamio.enums import GenreMusic
 from shazamio.algorithm import SignatureGenerator
 from shazamio.exceptions import BadCityName, BadCountryName, BadParseData
@@ -110,7 +108,11 @@ class Converter:
         }
 
     @staticmethod
-    def normalize_audio_data(audio: AudioSegment) -> AudioSegment:
+    def normalize_audio_data(audio):
+        try:
+            from pydub import AudioSegment
+        except ImportError:
+            raise ImportError("pydub is required for recognize_song. Install it with: pip install pydub")
         audio = audio.set_sample_width(2)
         audio = audio.set_frame_rate(16000)
         audio = audio.set_channels(1)
@@ -118,7 +120,7 @@ class Converter:
         return audio
 
     @staticmethod
-    def create_signature_generator(audio: AudioSegment) -> SignatureGenerator:
+    def create_signature_generator(audio) -> SignatureGenerator:
         signature_generator = SignatureGenerator()
         signature_generator.feed_input(audio.get_array_of_samples())
         signature_generator.MAX_TIME_SECONDS = 12

--- a/shazamio/utils.py
+++ b/shazamio/utils.py
@@ -9,8 +9,6 @@ from typing import Union
 import aiofiles
 import aiohttp
 from aiohttp import ContentTypeError
-from pydub import AudioSegment
-
 from shazamio.exceptions import FailedDecodeJson
 from shazamio.schemas.artists import ArtistQuery
 
@@ -30,7 +28,12 @@ async def get_file_bytes(file: FileT) -> bytes:
         return await f.read()
 
 
-async def get_song(data: SongT) -> Union[AudioSegment]:
+async def get_song(data: SongT):
+    try:
+        from pydub import AudioSegment
+    except ImportError:
+        raise ImportError("pydub is required for recognize_song. Install it with: pip install pydub")
+
     if isinstance(data, (str, pathlib.Path)):
         song_bytes = await get_file_bytes(file=data)
         return AudioSegment.from_file(BytesIO(song_bytes))


### PR DESCRIPTION
pydub is unmaintained and was a hard dependency even though it's only 
used by the deprecated recognize_song method. This moves it to an optional 
dependency... users who still rely on recognize_song can install it with 
pip install shazamio[legacy].

Closes #149 