### PR TITLE
Update recognize method to accept pathlib.Path

### DIFF
--- a/shazamio/api.py
+++ b/shazamio/api.py
@@ -567,7 +567,7 @@ class Shazam(Request):
 
     async def recognize(
         self,
-        data: Union[str, bytes, bytearray],
+        data: Union[str, pathlib.Path, bytes, bytearray],
         proxy: Optional[str] = None,
         options: Optional[SearchParams] = None,
     ) -> Dict[str, Any]:


### PR DESCRIPTION
isinstance accept str and pathlib.Path but in the type hinting its not included, so typing extension raise an error even if its not