### PR TITLE
ci(checks): fix the `autoblack` workflow and mark the dead-endpoint test `xfail`

### DIFF
--- a/.github/workflows/auto-black.yml
+++ b/.github/workflows/auto-black.yml
@@ -1,30 +1,34 @@
 # GitHub Action that uses Black to reformat the Python code in an incoming pull request.
-# If all Python code in the pull request is compliant with Black then this Action does nothing.
-# Othewrwise, Black is run and its changes are committed back to the incoming pull request.
-# https://github.com/cclauss/autoblack
+#  If all Python code in the pull request is compliant with Black then this Action does nothing.
+#  Otherwise, Black is run and its changes are committed back to the incoming pull request.
+#  https://github.com/cclauss/autoblack
 
 name: autoblack
-on: [pull_request, push]
+on: pull_request
+permissions:
+  contents: write
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v4
         with:
-          python-version: 3.9
+          ref: ${{ github.head_ref }}
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
       - name: Install Black
-        run: pip install black
+        run: pip install 'black==24.10.0'
       - name: Run black --check .
+        id: black-check
         run: black --check .
+        continue-on-error: true
       - name: If needed, commit black changes to the pull request
-        if: failure()
+        if: steps.black-check.outcome == 'failure'
         run: |
           black .
-          git config --global user.name 'autoblack'
-          git config --global user.email 'cclauss@users.noreply.github.com'
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
-          git checkout $GITHUB_HEAD_REF
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git commit -am "fixup: Format Python code with Black"
           git push

--- a/tests/test_about_artist.py
+++ b/tests/test_about_artist.py
@@ -2,15 +2,23 @@ import pytest
 
 from shazamio import Serialize
 from shazamio import Shazam
+from shazamio.exceptions import FailedDecodeJson
 from shazamio.schemas.artists import ArtistQuery
 from shazamio.schemas.enums import ArtistExtend
 from shazamio.schemas.enums import ArtistView
 
 
 @pytest.mark.asyncio
-async def test_about_artist():
+@pytest.mark.xfail(
+    raises=FailedDecodeJson,
+    strict=True,
+    reason="every https://www.shazam.com/services/amapi/v1/ path returns HTTP 405 with an HTML"
+    " body, so artist_about cannot get JSON back; remove this marker once the endpoint is"
+    " replaced or revives",
+)
+async def test_about_artist() -> None:
     shazam = Shazam(language="ES")
-    artist_id = 659860538
+    artist_id: int = 659860538
 
     about_artist = await shazam.artist_about(
         artist_id,


### PR DESCRIPTION
## What

Both permanently red checks, fixed in one place: the `autoblack` workflow that dies before black is installed, and the test that fails because the upstream endpoint it calls is gone.

### `autoblack`

The job has been failing on every run. It dies before black is ever installed:

```
Set up Python 3.9
##[error]Version 3.9 with arch x64 not found
Available versions:
3.10.21 (x64)
3.11.16 (x64)
3.12.14 (x64)
3.13.15 (x64)
3.14.7 (x64)
```

and because the commit step was gated on `if: failure()`, it then ran without black on the PATH:

```
/home/runner/work/_temp/74a1f755-4227-4998-a5ff-65d67db90fab.sh: line 1: black: command not found
##[error]Process completed with exit code 127.
```

Changes:

- `actions/checkout@v1` and `actions/setup-python@v1` become `@v4`/`@v5`, on Python 3.10 (the project floor; v1 cannot download interpreters, and 3.9 left the runner images).
- `black` is pinned to `24.10.0`, matching the `^24.2.0` dev constraint. Probed against the current tree: 24.10.0 leaves all 66 files unchanged, so the pin adds zero churn (latest black, 26.5.1, would reformat one file).
- The commit step is gated on the check step's own outcome instead of `if: failure()`, so an infrastructure failure can no longer trigger it.
- The workflow runs on `pull_request` only. On `push` events `GITHUB_HEAD_REF` is empty, so the commit half never worked there; master pushes keep their black coverage through the check in the test workflow.
- Checkout uses `ref: ${{ github.head_ref }}` and the job declares `permissions: contents: write`, replacing the manual `git remote set-url`/`git checkout` dance; the fixup commit is authored by `github-actions[bot]`.

As before, the commit-back step cannot push to a pull request opened from a fork: `GITHUB_TOKEN` has no write access there. The check half still reports.

### `test_about_artist`

The failure is about the upstream service, not about any change under review. Every path under `https://www.shazam.com/services/amapi/v1/` returns HTTP 405 with an HTML body, so `artist_about` never gets JSON back:

```
$ curl -sS -o /dev/null -w '%{http_code}\n' -A 'Mozilla/5.0' \
    'https://www.shazam.com/services/amapi/v1/catalog/GB/artists/659860538'
405
```

Before, on `master`:

```
>           raise FailedDecodeJson("Failed to decode json") from e
E           shazamio.exceptions.FailedDecodeJson: Failed to decode json
==================== 1 failed, 7 passed, 1 warning in 2.70s ====================
```

The test is now marked `xfail(strict=True, raises=FailedDecodeJson)`:

```
=================== 7 passed, 1 xfailed, 1 warning in 5.01s ====================
```

`strict=True` makes the marker self-removing: the moment the endpoint starts answering with JSON again, the test reports `XPASS` and fails the suite, so the marker cannot outlive the outage. `raises=FailedDecodeJson` keeps any other failure (a schema change, a serialization bug) a real failure instead of an expected one.

What this does not fix: `artist_about` and every other method built on `services/amapi/v1` (`top_world_tracks`, `top_country_tracks`, `top_city_tracks`, `top_world_genre_tracks`, `top_country_genre_tracks`, `artist_albums`, `search_album`) still raise at runtime. That is lost upstream surface, not a code bug.

## Why

Permanently red checks train everyone to ignore red checks, and they hide real failures introduced by a pull request.

## How to test

This pull request runs the fixed `autoblack` workflow itself; the check passes because the tree is already black-compliant. Locally: `poetry run pytest` gives `7 passed, 1 xfailed`, and `pip install 'black==24.10.0' && black --check .` leaves 66 files unchanged.
