### PR TITLE
ci(autoblack): check out the fork head so fork pull requests can run

### DIFF
--- a/.github/workflows/auto-black.yml
+++ b/.github/workflows/auto-black.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # `repository` defaults to the base repository, which does not hold a
+          #  fork's branch, so checkout on a fork pull request died before black
+          #  was ever installed.
+          #  https://github.com/actions/checkout/blob/11d5960a326750d5838078e36cf38b85af677262/action.yml#L4-L6
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -25,10 +30,15 @@ jobs:
         run: black --check .
         continue-on-error: true
       - name: If needed, commit black changes to the pull request
-        if: steps.black-check.outcome == 'failure'
+        # `GITHUB_TOKEN` is read-only on fork pull requests, so only same-repository
+        #  ones get the fixup commit; fork ones fail the step below instead.
+        if: steps.black-check.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           black .
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git commit -am "fixup: Format Python code with Black"
           git push
+      - name: Fail when black reports issues on a fork pull request
+        if: steps.black-check.outcome == 'failure' && github.event.pull_request.head.repo.full_name != github.repository
+        run: exit 1


### PR DESCRIPTION
## What

The `autoblack` job dies on every pull request opened from a fork, before black is ever installed. `actions/checkout` was given `ref: ${{ github.head_ref }}` but no `repository`, and `repository` defaults to the base repository — which does not hold the fork's branch, so the fetch retries and fails:

```
/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/fix-json-decode-error*:refs/remotes/origin/fix-json-decode-error* ...
The process '/usr/bin/git' failed with exit code 1
##[error]The process '/usr/bin/git' failed with exit code 1
```

Changes:

- checkout now passes `repository: ${{ github.event.pull_request.head.repo.full_name }}`, so the branch is fetched from wherever it actually lives — the fork for outside contributions, this repository for our own branches;
- the commit-back step is additionally gated on the head repository being this one: `GITHUB_TOKEN` is read-only on fork pull requests, so the push there could never work anyway — before, an unformatted fork PR would have attempted it and died confusingly;
- a new final step fails the job explicitly when black finds issues on a fork pull request, so the check still reports instead of ending green with nothing committed.

## Why

The previous rework of this workflow fixed it for same-repository branches and was only ever exercised on those; the first fork pull request to arrive after it hit this path and went red on infrastructure rather than on formatting.

## How to test

This pull request comes from a same-repository branch, so it exercises that path itself. The fork path cannot be exercised from here; the next fork pull request update will show it — the check step will run instead of dying in checkout.
