### PR TITLE
refactor(schemas): extract the section and artist unions into `TrackSectionType` and `ArtistType`

### DIFF
--- a/shazamio/schemas/artists.py
+++ b/shazamio/schemas/artists.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
 from dataclasses import field
+from typing import Annotated
 from typing import Any
 from typing import List
 from typing import Optional
+from typing import TypeAlias
 from typing import Union
 
 from pydantic import AliasPath
@@ -51,6 +53,14 @@ class ArtistInfo(BaseModel):
 
 class ArtistV2(BaseModel):
     artist: ArtistInfo
+
+
+# `left_to_right` keeps the old parser's first-match union semantics; the two
+#  shapes share no field a discriminator could read.
+ArtistType: TypeAlias = Annotated[
+    Union[ArtistV2, ArtistInfo],
+    Field(union_mode="left_to_right"),
+]
 
 
 @dataclass

--- a/shazamio/schemas/models.py
+++ b/shazamio/schemas/models.py
@@ -3,6 +3,7 @@ from typing import Any
 from typing import List
 from typing import Literal
 from typing import Optional
+from typing import TypeAlias
 from typing import Union
 from urllib.parse import urlencode
 from urllib.parse import urlparse
@@ -94,6 +95,18 @@ class RelatedSection(BaseModel):
     tab_name: str = Field(validation_alias="tabname")
 
 
+TrackSectionType: TypeAlias = Annotated[
+    Union[
+        SongSection,
+        VideoSection,
+        LyricsSection,
+        RelatedSection,
+        ArtistSection,
+    ],
+    Field(discriminator="type"),
+]
+
+
 class DimensionsModel(BaseModel):
     width: int
     height: int
@@ -161,20 +174,7 @@ class TrackInfo(BaseModel):
         validation_alias=AliasPath("hub", "providers", 0, "actions", 1, "uri"),
     )
     youtube_link: Optional[str] = None
-    sections: Optional[
-        List[
-            Annotated[
-                Union[
-                    SongSection,
-                    VideoSection,
-                    LyricsSection,
-                    RelatedSection,
-                    ArtistSection,
-                ],
-                Field(discriminator="type"),
-            ]
-        ]
-    ] = Field(default_factory=list)
+    sections: Optional[List[TrackSectionType]] = Field(default_factory=list)
 
     def model_post_init(self, context: Any, /) -> None:
         self.shazam_url = f"https://www.shazam.com/track/{self.artist_id}"

--- a/shazamio/serializers.py
+++ b/shazamio/serializers.py
@@ -1,23 +1,18 @@
-from typing import Annotated, Any, Dict, Final, List, Union
+from typing import Any, Dict, Final, List
 
-from pydantic import Field
 from pydantic import TypeAdapter
 
 from shazamio.schemas.base import BaseDataModel
 from shazamio.schemas.artist.views.full_albums import FullAlbumsModel
-from shazamio.schemas.artists import ArtistInfo
 from shazamio.schemas.artists import ArtistResponse
-from shazamio.schemas.artists import ArtistV2
+from shazamio.schemas.artists import ArtistType
 from shazamio.schemas.models import ResponseTrack
 from shazamio.schemas.models import TrackInfo
 from shazamio.schemas.models import YoutubeData
 from shazamio.schemas.album import AlbumModel
 from shazamio.schemas.playlist.playlist import PlayList
 
-# `left_to_right` keeps the old parser's first-match union semantics.
-ARTIST_ADAPTER: Final = TypeAdapter(
-    Annotated[Union[ArtistV2, ArtistInfo], Field(union_mode="left_to_right")]
-)
+ARTIST_ADAPTER: Final = TypeAdapter(ArtistType)
 
 
 class Serialize:
@@ -46,7 +41,7 @@ class Serialize:
         return FullAlbumsModel.model_validate(data)
 
     @classmethod
-    def artist(cls, data: Dict[str, Any]) -> Union[ArtistV2, ArtistInfo]:
+    def artist(cls, data: Dict[str, Any]) -> ArtistType:
         return ARTIST_ADAPTER.validate_python(data)
 
     @classmethod


### PR DESCRIPTION
## What

- The five-way section union spelled out inside `TrackInfo.sections` is now a named alias, `TrackSectionType` in `shazamio/schemas/models.py`, next to the section models it unites. It keeps the `Field(discriminator="type")` metadata.
- The artist union that lived inline inside `ARTIST_ADAPTER` in `shazamio/serializers.py` is now `ArtistType` in `shazamio/schemas/artists.py`, next to `ArtistV2` and `ArtistInfo`. It keeps `Field(union_mode="left_to_right")`, with a comment on why no discriminator is possible: the two shapes share no field one could read.
- `serializers.py` builds the adapter from the alias and `Serialize.artist` returns it; the duplicated union spelling and its comment are gone, along with the imports only they used.

## Why

Both unions were written out at their use sites, so reading a signature meant parsing the whole `Annotated[Union[...], Field(...)]` expression, and the artist union existed in one place the section union could not point at. A named alias beside the models is one definition with one home.

The aliases use `typing.TypeAlias`, not the `type` statement: the package floor is Python 3.10 and the statement needs 3.12.

## How to test

`pytest tests/ -q` on 3.10 and 3.14: `10 passed, 1 xfailed` on both. No behavior change is intended; validation semantics (`type` discriminator for sections, first-match for artists) are carried by the same `Field` metadata, only named.
