### PR TITLE
chore(just): add a `justfile` and make CI call its recipes

### DIFF
--- a/.github/actions/setup-just/action.yml
+++ b/.github/actions/setup-just/action.yml
@@ -1,0 +1,23 @@
+name: Set up `just`
+description: Install `uv` and the `just` runner.
+
+inputs:
+  python-version:
+    description: Python version for `uv` to pin; empty leaves the choice to `uv`.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      with:
+        python-version: ${{ inputs.python-version }}
+        enable-cache: true
+
+    # No version: upstream promises no release breaks an existing `justfile` and that
+    #  there will never be a `just` 2.0, so a pin could only strand us on a version
+    #  carrying a bug, with nothing to bump it. `just --fmt` is the one carve-out from
+    #  that promise, and no recipe here calls it.
+    #  https://github.com/casey/just/blob/7f4ef81bd6a93faa2b28430912c8e9ab0e3dd29a/README.md#L501
+    - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4

--- a/.github/workflows/auto-black.yml
+++ b/.github/workflows/auto-black.yml
@@ -19,26 +19,28 @@ jobs:
           #  https://github.com/actions/checkout/blob/3d3c42e5aac5ba805825da76410c181273ba90b1/action.yml#L4-L6
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+
+      - name: Install uv and just
+        uses: ./.github/actions/setup-just
         with:
           python-version: "3.10"
-      - name: Install Black
-        run: pip install 'black==26.5.1'
-      - name: Run black --check .
+
+      - name: Check the formatting
         id: black-check
-        run: black --check .
+        run: just lint
         continue-on-error: true
+
       - name: If needed, commit black changes to the pull request
         # `GITHUB_TOKEN` is read-only on fork pull requests, so only same-repository
         #  ones get the fixup commit; fork ones fail the step below instead.
         if: steps.black-check.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
-          black .
+          just format
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git commit -am "fixup: Format Python code with Black"
           git push
+
       - name: Fail when black reports issues on a fork pull request
         if: steps.black-check.outcome == 'failure' && github.event.pull_request.head.repo.full_name != github.repository
         run: exit 1

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,11 +13,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Install uv and just
+        uses: ./.github/actions/setup-just
         with:
           python-version: ${{ matrix.python-version }}
-          enable-cache: true
 
       # `FedericoCarboni/setup-ffmpeg` resolves its download by scraping a
       #  third-party readme at run time and failed two runs in one day with
@@ -26,10 +25,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
 
       - name: Install dependencies
-        run: uv sync --locked
+        run: just install
 
-      - name: Check black
-        run: uv run black --check .
+      - name: Check the formatting
+        run: just lint
 
       - name: Run tests
-        run: uv run pytest
+        run: just test

--- a/justfile
+++ b/justfile
@@ -1,0 +1,30 @@
+# The one home of every command this project runs. A CI job and a local check are
+#  the same string here rather than two copies that drift apart.
+
+# `bash` on the CI runners and on a developer machine, so a recipe behaves the
+#  same everywhere. The default is `sh`, which on Windows is whatever Git happens
+#  to have put on `PATH`.
+set shell := ["bash", "-uc"]
+
+[doc("Show the recipes")]
+default:
+    @just --list
+
+[doc("Install the dependencies, exactly as locked")]
+install:
+    uv sync --locked
+
+[doc("Check the formatting")]
+lint:
+    uv run black --check .
+
+[doc("Reformat the tree")]
+format:
+    uv run black .
+
+[doc("Run the test suite")]
+test:
+    uv run pytest
+
+[doc("Run everything CI runs")]
+ci: lint test


### PR DESCRIPTION
## What

- A `justfile` holds every command the project runs: `sync` (`uv sync --locked`), `fmt` and `lint` (black, for now), `test`, and `all` for the whole gate.
- The test and autoblack workflows call the recipes instead of restating the commands. Installing `uv` and `just` is a local composite action, `.github/actions/setup-just`, with a `python-version` input for the test matrix.
- The autoblack workflow loses its own `pip install 'black==26.5.1'` pin: the recipe resolves black from the lockfile, so the format gate and a local `just lint` can no longer run different versions.

## Why

A CI job and a local check should be the same string. Until now the black version lived in two places (`pyproject.toml` and the workflow) and the test commands in two more; every future tool change would have to be made twice. The publish workflow is left as is: its release commands are being reworked separately.

## How to test

`just all`: formatting check plus the suite, `10 passed, 1 xfailed`. `just --list` shows the recipes.
