### PR TITLE
build(deps): drop the habit caps and verify the floors

### DIFF
--- a/justfile
+++ b/justfile
@@ -28,5 +28,22 @@ format:
 test:
     uv run pytest
 
+[doc("Run the test suite against the oldest dependency versions the floors allow")]
+test-floor:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # `--resolution lowest-direct` rewrites `uv.lock`; keep the real one aside
+    #  and restore it whatever the suite says.
+    lock_backup="$(mktemp)"
+    cp uv.lock "${lock_backup}"
+    trap 'mv "${lock_backup}" uv.lock && uv sync' EXIT
+
+    # Floors bind hardest on the oldest supported interpreter. `--upgrade` is
+    #  what makes the strategy apply: without it the resolver keeps the locked
+    #  versions, which already satisfy the floors.
+    uv sync --python 3.10 --upgrade --resolution lowest-direct
+    uv run --no-sync --python 3.10 pytest
+
 [doc("Run everything CI runs")]
 ci: lint test

--- a/justfile
+++ b/justfile
@@ -6,6 +6,10 @@
 #  to have put on `PATH`.
 set shell := ["bash", "-uc"]
 
+# The oldest interpreter this package supports, read from `requires-python` in
+#  `pyproject.toml` so the two cannot drift.
+python_floor := `sed -n 's/^requires-python = ">=\([0-9]*\.[0-9]*\).*/\1/p' pyproject.toml`
+
 [doc("Show the recipes")]
 default:
     @just --list
@@ -42,8 +46,8 @@ test-floor:
     # Floors bind hardest on the oldest supported interpreter. `--upgrade` is
     #  what makes the strategy apply: without it the resolver keeps the locked
     #  versions, which already satisfy the floors.
-    uv sync --python 3.10 --upgrade --resolution lowest-direct
-    uv run --no-sync --python 3.10 pytest
+    uv sync --python {{ python_floor }} --upgrade --resolution lowest-direct
+    uv run --no-sync --python {{ python_floor }} pytest
 
 [doc("Run everything CI runs")]
 ci: lint test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,24 +19,25 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
+# Floors only, verified by `just test-floor`; a library's upper caps conflict
+#  with everything else in a consumer's environment, so a cap needs a reason.
 dependencies = [
-    "numpy>=2.2.2,<3",
+    "numpy>=2.2.2",
     # Every release below 3.14.3 carries at least one open advisory, request
     #  smuggling and header injection among them.
     #  https://github.com/aio-libs/aiohttp/security/advisories
-    "aiohttp>=3.14.3,<4",
-    "pydub>=0.25.1,<0.26",
+    "aiohttp>=3.14.3",
+    "pydub>=0.25.1",
     # `audioop` left the standard library in 3.13, and `pydub` imports it at module
     #  scope: `import pydub` raises `ModuleNotFoundError: No module named 'pyaudioop'`.
     #  `pydub` has not released since 2021, so the shim is ours to declare.
     #  https://docs.python.org/3.13/whatsnew/3.13.html#pep-594-remove-dead-batteries-from-the-standard-library
-    "audioop-lts>=0.2.2,<0.3; python_version >= '3.13'",
-    # A lower cap here excluded 24.x and 25.x, which conflicts with anything else
-    #  in the environment that asks for a current `aiofiles`. Only `aiofiles.open`
-    #  is used.
-    "aiofiles>=23.2.1,<26.0.0",
-    "aiohttp-retry>=2.8.3,<3",
-    "pydantic>=2.9.2,<3",
+    "audioop-lts>=0.2.2; python_version >= '3.13'",
+    "aiofiles>=23.2.1",
+    "aiohttp-retry>=2.8.3",
+    "pydantic>=2.9.2",
+    # The sibling crate is released in lockstep with this package; an exact pin
+    #  ships the one pair that was tested together.
     "shazamio-core==1.2.0",
 ]
 
@@ -51,8 +52,8 @@ dev = [
     { include-group = "lint" },
 ]
 tests = [
-    "pytest==8.1.2",
-    "pytest-asyncio>=0.23.6,<0.24",
+    "pytest>=8.1.2",
+    "pytest-asyncio>=0.23.6",
 ]
 lint = [
     "ruff>=0.16.5",
@@ -67,6 +68,9 @@ lint = [
 exclude-newer = "7 days"
 
 [build-system]
+# The cap stays: `uv_build` is pre-1.0 and the bounded minor range is the shape
+#  its own docs prescribe.
+#  https://docs.astral.sh/uv/concepts/build-backend/
 requires = ["uv_build>=0.12.8,<0.13"]
 build-backend = "uv_build"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,23 +19,37 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-# Floors only, verified by `just test-floor`; a library's upper caps conflict
-#  with everything else in a consumer's environment, so a cap needs a reason.
+# Floors only, verified by `just test-floor`: each one is the oldest release the
+#  suite passes with, and the comment says what breaks one release below it. A
+#  library's upper caps conflict with everything else in a consumer's
+#  environment, so a cap needs a reason.
 dependencies = [
-    "numpy>=2.2.2",
+    # Oldest release with CPython 3.10 wheels on every platform; 1.21.2 shipped
+    #  them for Linux only.
+    "numpy>=1.21.3",
     # Every release below 3.14.3 carries at least one open advisory, request
     #  smuggling and header injection among them.
     #  https://github.com/aio-libs/aiohttp/security/advisories
     "aiohttp>=3.14.3",
-    "pydub>=0.25.1",
+    # `AudioSegment.get_array_of_samples`, which the converter feeds to the
+    #  signature generator, first appeared in 0.16.0: 0.15.0 fails the suite
+    #  with `AttributeError`.
+    "pydub>=0.16.0",
     # `audioop` left the standard library in 3.13, and `pydub` imports it at module
     #  scope: `import pydub` raises `ModuleNotFoundError: No module named 'pyaudioop'`.
-    #  `pydub` has not released since 2021, so the shim is ours to declare.
+    #  `pydub` has not released since 2021, so the shim is ours to declare. Every
+    #  release passes the suite; 0.2.2 is the only one shipping CPython 3.14 wheels.
     #  https://docs.python.org/3.13/whatsnew/3.13.html#pep-594-remove-dead-batteries-from-the-standard-library
     "audioop-lts>=0.2.2; python_version >= '3.13'",
-    "aiofiles>=23.2.1",
-    "aiohttp-retry>=2.8.3",
-    "pydantic>=2.9.2",
+    # `async with aiofiles.open(...)` needs the async context manager added in
+    #  0.3.0: 0.2.1 fails the suite with `AttributeError: __aenter__`.
+    "aiofiles>=0.3.0",
+    # `RetryOptionsBase` is first exported in 2.3: 2.2 fails at import.
+    "aiohttp-retry>=2.3",
+    # The suite passes down to 2.0.3, but `Field(union_mode="left_to_right")` on
+    #  the artist union is silently ignored before 2.2.0, so the union parses in
+    #  smart mode there.
+    "pydantic>=2.2.0",
     # The sibling crate is released in lockstep with this package; an exact pin
     #  ships the one pair that was tested together.
     "shazamio-core==1.2.0",
@@ -52,8 +66,11 @@ dev = [
     { include-group = "lint" },
 ]
 tests = [
-    "pytest>=8.1.2",
-    "pytest-asyncio>=0.23.6",
+    # The oldest release `pytest-asyncio` below can run on; the suite passes there.
+    "pytest>=7.0.0",
+    # The session-scoped async fixtures error at teardown on 0.23.2 and hit
+    #  `ScopeMismatch` on anything below 0.23.
+    "pytest-asyncio>=0.23.3",
 ]
 lint = [
     "ruff>=0.16.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,8 @@ dependencies = [
     # Oldest release with CPython 3.10 wheels on every platform; 1.21.2 shipped
     #  them for Linux only.
     "numpy>=1.21.3",
-    # Every release below 3.14.3 carries at least one open advisory, request
-    #  smuggling and header injection among them.
-    #  https://github.com/aio-libs/aiohttp/security/advisories
-    "aiohttp>=3.14.3",
+    # Oldest release with CPython 3.10 wheels; 3.7.4.post0 ships none at all.
+    "aiohttp>=3.8.0",
     # `AudioSegment.get_array_of_samples`, which the converter feeds to the
     #  signature generator, first appeared in 0.16.0: 0.15.0 fails the suite
     #  with `AttributeError`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,8 +83,11 @@ lint = [
 exclude-newer = "7 days"
 
 [build-system]
-# The cap stays: `uv_build` is pre-1.0 and the bounded minor range is the shape
-#  its own docs prescribe.
+# `uv_build` is pre-1.0, so a minor (`0.13`) is allowed to break the build; the
+#  range takes `0.12.x` patches automatically and holds the next series back.
+#  Bumping to a new series is fine and routine: raise both bounds, run
+#  `uv build`, and check the wheel still looks right. The bounded shape is what
+#  uv's own docs prescribe.
 #  https://docs.astral.sh/uv/concepts/build-backend/
 requires = ["uv_build>=0.12.8,<0.13"]
 build-backend = "uv_build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,6 @@ build-backend = "uv_build"
 module-root = ""
 
 [tool.pytest.ini_options]
-addopts = "-scoped"
 asyncio_mode = "auto"
 filterwarnings = ["ignore::DeprecationWarning"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     #  in the environment that asks for a current `aiofiles`. Only `aiofiles.open`
     #  is used.
     "aiofiles>=23.2.1,<26.0.0",
-    "anyio>=4.3.0,<5",
     "aiohttp-retry>=2.8.3,<3",
     "pydantic>=2.9.2,<3",
     "shazamio-core==1.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -202,20 +202,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anyio"
-version = "4.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
-]
-
-[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1084,7 +1070,6 @@ dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
     { name = "aiohttp-retry" },
-    { name = "anyio" },
     { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1112,7 +1097,6 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=23.2.1,<26.0.0" },
     { name = "aiohttp", specifier = ">=3.14.3,<4" },
     { name = "aiohttp-retry", specifier = ">=2.8.3,<3" },
-    { name = "anyio", specifier = ">=4.3.0,<5" },
     { name = "audioop-lts", marker = "python_full_version >= '3.13'", specifier = ">=0.2.2,<0.3" },
     { name = "numpy", specifier = ">=2.2.2,<3" },
     { name = "pydantic", specifier = ">=2.9.2,<3" },

--- a/uv.lock
+++ b/uv.lock
@@ -1116,7 +1116,7 @@ tests = [
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = ">=0.3.0" },
-    { name = "aiohttp", specifier = ">=3.14.3" },
+    { name = "aiohttp", specifier = ">=3.8.0" },
     { name = "aiohttp-retry", specifier = ">=2.3" },
     { name = "audioop-lts", marker = "python_full_version >= '3.13'", specifier = ">=0.2.2" },
     { name = "numpy", specifier = ">=1.21.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -1115,26 +1115,26 @@ tests = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles", specifier = ">=23.2.1" },
+    { name = "aiofiles", specifier = ">=0.3.0" },
     { name = "aiohttp", specifier = ">=3.14.3" },
-    { name = "aiohttp-retry", specifier = ">=2.8.3" },
+    { name = "aiohttp-retry", specifier = ">=2.3" },
     { name = "audioop-lts", marker = "python_full_version >= '3.13'", specifier = ">=0.2.2" },
-    { name = "numpy", specifier = ">=2.2.2" },
-    { name = "pydantic", specifier = ">=2.9.2" },
-    { name = "pydub", specifier = ">=0.25.1" },
+    { name = "numpy", specifier = ">=1.21.3" },
+    { name = "pydantic", specifier = ">=2.2.0" },
+    { name = "pydub", specifier = ">=0.16.0" },
     { name = "shazamio-core", specifier = "==1.2.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pytest", specifier = ">=8.1.2" },
-    { name = "pytest-asyncio", specifier = ">=0.23.6" },
+    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.3" },
     { name = "ruff", specifier = ">=0.16.5" },
 ]
 lint = [{ name = "ruff", specifier = ">=0.16.5" }]
 tests = [
-    { name = "pytest", specifier = ">=8.1.2" },
-    { name = "pytest-asyncio", specifier = ">=0.23.6" },
+    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.3" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -276,6 +276,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1009,8 +1018,17 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
 name = "pytest"
-version = "8.1.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1018,23 +1036,26 @@ dependencies = [
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/1f/dd3960a2369182720e8cbd580523a4f75292c0c75197dd0254c95f4a0add/pytest-8.1.2.tar.gz", hash = "sha256:f3c45d1d5eed96b01a2aea70dee6a4a366d51d38f9957768083e4fecfc77f3ef", size = 1410060, upload-time = "2024-04-26T18:05:17.884Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/d7/a812a0bd0f5160823e647524488cc9734f93782f2c273b8f77e8afc60a37/pytest-8.1.2-py3-none-any.whl", hash = "sha256:6c06dc309ff46a05721e6fd48e492a775ed8165d2ecdf57f156a80c7e95bb142", size = 337456, upload-time = "2024-04-26T18:05:15.452Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.23.8"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
     { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/b4/0b378b7bf26a8ae161c3890c0b48a91a04106c5713ce81b4b080ea2f4f18/pytest_asyncio-0.23.8.tar.gz", hash = "sha256:759b10b33a6dc61cce40a8bd5205e302978bbbcc00e279a8b61d9a6a3c82e4d3", size = 46920, upload-time = "2024-07-17T17:39:34.617Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/82/62e2d63639ecb0fbe8a7ee59ef0bc69a4669ec50f6d3459f74ad4e4189a2/pytest_asyncio-0.23.8-py3-none-any.whl", hash = "sha256:50265d892689a5faefb84df80819d1ecef566eb3549cf915dfb33569359d1ce2", size = 17663, upload-time = "2024-07-17T17:39:32.478Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]
@@ -1094,26 +1115,26 @@ tests = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles", specifier = ">=23.2.1,<26.0.0" },
-    { name = "aiohttp", specifier = ">=3.14.3,<4" },
-    { name = "aiohttp-retry", specifier = ">=2.8.3,<3" },
-    { name = "audioop-lts", marker = "python_full_version >= '3.13'", specifier = ">=0.2.2,<0.3" },
-    { name = "numpy", specifier = ">=2.2.2,<3" },
-    { name = "pydantic", specifier = ">=2.9.2,<3" },
-    { name = "pydub", specifier = ">=0.25.1,<0.26" },
+    { name = "aiofiles", specifier = ">=23.2.1" },
+    { name = "aiohttp", specifier = ">=3.14.3" },
+    { name = "aiohttp-retry", specifier = ">=2.8.3" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13'", specifier = ">=0.2.2" },
+    { name = "numpy", specifier = ">=2.2.2" },
+    { name = "pydantic", specifier = ">=2.9.2" },
+    { name = "pydub", specifier = ">=0.25.1" },
     { name = "shazamio-core", specifier = "==1.2.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pytest", specifier = "==8.1.2" },
-    { name = "pytest-asyncio", specifier = ">=0.23.6,<0.24" },
+    { name = "pytest", specifier = ">=8.1.2" },
+    { name = "pytest-asyncio", specifier = ">=0.23.6" },
     { name = "ruff", specifier = ">=0.16.5" },
 ]
 lint = [{ name = "ruff", specifier = ">=0.16.5" }]
 tests = [
-    { name = "pytest", specifier = "==8.1.2" },
-    { name = "pytest-asyncio", specifier = ">=0.23.6,<0.24" },
+    { name = "pytest", specifier = ">=8.1.2" },
+    { name = "pytest-asyncio", specifier = ">=0.23.6" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

- Runtime and test dependencies now declare verified floors instead of habit
  caps: the `<3` / `<4`-style uppers are gone, `pytest==8.1.2` is a floor, and
  the unused `anyio` is removed (nothing in the tree imports it).
- `shazamio-core` keeps its exact pin (the crate is released in lockstep with
  this package), and `uv_build` keeps the bounded minor range its own docs
  prescribe.
- Every floor is the oldest release the suite actually passes with, found by
  walking each package down release by release; the comment on each one in
  `pyproject.toml` names what breaks one release below it (`pydub` 0.15.0 has
  no `get_array_of_samples`, `aiofiles` 0.2.1 has no async context manager,
  `aiohttp-retry` 2.2 does not export `RetryOptionsBase`, pydantic below 2.2.0
  silently ignores `union_mode="left_to_right"`, and so on).
- A `test-floor` recipe resolves the whole tree with
  `--resolution lowest-direct` on the oldest supported interpreter (derived
  from `requires-python`) and runs the suite there, so every floor is provable
  on demand:

      $ just test-floor
      + aiofiles==0.3.0
      + aiohttp==3.8.0
      + aiohttp-retry==2.3
      + numpy==1.21.3
      + pydantic==2.2.0
      + pydub==0.16.0
      + pytest==7.0.0
      + pytest-asyncio==0.23.3
      ...
      ================== 10 passed, 1 xfailed, 3 warnings in 3.65s ===================

  The other end holds too: the lock carries `pytest 9.1.1` and
  `pytest-asyncio 1.4.0`, and the suite passes there as well.

- `addopts = "-scoped"` is removed from `[tool.pytest.ini_options]`: `-scoped`
  is not a pytest option, it silently acted as `-s` and disabled output
  capture. With a test that prints:

      $ pytest -scoped test_probe.py -q
      CAPTURED-OR-NOT
      1 passed in 0.01s

      $ pytest test_probe.py -q
      1 passed in 0.01s

## Why

A library's upper caps conflict with everything else in a consumer's
environment, so a cap needs a reason; none of these had one, and the two that
do (the lockstep core pin, the pre-1.0 build backend) now say so in a comment.

## How to test

`just test-floor`, then `just ci`.
