### PR TITLE
ci(workflows): drop the duplicated lint run and filter docs-only pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,13 @@
 #  code: fixes are the author's to make locally, with `just format`.
 
 name: lint
-on: pull_request
+
+# What the filter costs and when it stops being safe: `.github/workflows/pytest.yml`.
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - LICENSE.txt
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,8 +27,5 @@ jobs:
       - name: Install dependencies
         run: just install
 
-      - name: Check the formatting
-        run: just lint
-
       - name: Run tests
         run: just test

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,14 @@
 name: test
 
-on: pull_request
+# Safe only while `master` requires no status checks: `paths-ignore` skips the
+#  whole workflow, and a required check from a run that never happened stays
+#  pending forever. Move the filter into a gate job's `if:` if that changes.
+#  https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - LICENSE.txt
 
 jobs:
   test:


### PR DESCRIPTION
## What

Two changes to the pull request gates.

**The linter ran six times per pull request; now it runs once.** The test
workflow had a `just lint` step inside its five-interpreter matrix, and
`lint.yml` runs the same recipe as its whole job. `just lint` is
`ruff format --check .` plus `ruff check .` — neither reads the interpreter it
runs under, so five of those six runs could only ever repeat the sixth. The step
is gone from the test workflow; `lint.yml` is untouched and still fails the pull
request on any finding.

**A pull request that only touches documentation no longer starts the test or
lint workflows.** Both now carry a `paths-ignore` filter:

```yaml
on:
  pull_request:
    paths-ignore:
      - "**.md"
      - LICENSE.txt
```

`**.md` is GitHub's own idiom for "any Markdown file at any depth", and the
documented behaviour of the filter is that "when all the path names match
patterns in `paths-ignore`, the workflow will not run".

The list is deliberately short. `.gitignore` is not on it: `ruff` respects it
when discovering files, so editing it changes what `just lint` reads.

## Why

The filter is on the trigger rather than in a gate job, which is the simpler of
the two shapes and the one that stops being safe if the repository ever requires
status checks — a required check belonging to a run that never happened stays
pending forever, and the pull request cannot be merged. `master` requires none
today. The condition is recorded as a comment in the workflow, with the link,
so the next person to add a required check finds it there rather than through a
stuck pull request.

`build.yml` and `codeql.yml` are unfiltered on purpose. `build.yml` triggers on
`release: created`, which carries no diff to filter against. CodeQL is a security
scan: skipping it on a documentation change would save about two runner-minutes
and would add a way for a scan to be missed quietly, which is the worse trade.

## How to test

The filter cannot be exercised by this pull request — its own diff is two
workflow files, so both workflows are expected to run here, which is what shows
the filter does not over-block. The skip itself will show on the first
documentation-only pull request after this merges: neither `test` nor `lint`
should appear in its check list.
