### PR TITLE
feat(api): define and type the public surface

### DIFF
--- a/examples/about_artist.py
+++ b/examples/about_artist.py
@@ -6,7 +6,7 @@ from shazamio.schemas.artists import ArtistQuery
 from shazamio.schemas.enums import ArtistExtend, ArtistView
 
 
-async def main():
+async def main() -> None:
     shazam = Shazam(language="ES")
     artist_id = 1124753799
     # extend: artistBio,bornOrFormed,editorialArtwork,origin

--- a/examples/about_track.py
+++ b/examples/about_track.py
@@ -3,7 +3,7 @@ import asyncio
 from shazamio import Serialize, Shazam
 
 
-async def main():
+async def main() -> None:
     shazam = Shazam()
     track_id = 53982678
     about_track = await shazam.track_about(track_id=track_id)

--- a/examples/album_info.py
+++ b/examples/album_info.py
@@ -3,7 +3,7 @@ import asyncio
 from shazamio import Serialize, Shazam
 
 
-async def main():
+async def main() -> None:
     shazam = Shazam()
     albums = await shazam.search_album(album_id=1544741796)
     serialized = Serialize.album_info(data=albums)

--- a/examples/artist_albums.py
+++ b/examples/artist_albums.py
@@ -3,7 +3,7 @@ import asyncio
 from shazamio import Serialize, Shazam
 
 
-async def main():
+async def main() -> None:
     shazam = Shazam()
     artist_id = 1300793014
     albums = await shazam.artist_albums(artist_id=artist_id)

--- a/examples/recognize_and_get_album.py
+++ b/examples/recognize_and_get_album.py
@@ -13,7 +13,7 @@ logging.basicConfig(
 )
 
 
-async def main():
+async def main() -> None:
     shazam = Shazam(
         http_client=HTTPClient(
             retry_options=ExponentialRetry(

--- a/examples/recognize_song.py
+++ b/examples/recognize_song.py
@@ -14,7 +14,7 @@ logging.basicConfig(
 )
 
 
-async def main():
+async def main() -> None:
     shazam = Shazam(
         http_client=HTTPClient(
             retry_options=ExponentialRetry(

--- a/examples/recognize_track_youtube.py
+++ b/examples/recognize_track_youtube.py
@@ -3,7 +3,7 @@ import asyncio
 from shazamio import Serialize, Shazam
 
 
-async def main():
+async def main() -> None:
     shazam = Shazam()
     out = await shazam.recognize_song("data/dora.ogg")
     result = Serialize.full_track(data=out)

--- a/examples/related_tracks.py
+++ b/examples/related_tracks.py
@@ -3,7 +3,7 @@ import asyncio
 from shazamio import Shazam
 
 
-async def main():
+async def main() -> None:
     shazam = Shazam()
     track_id = 546891609
     related = await shazam.related_tracks(track_id=track_id, limit=5, offset=2)

--- a/examples/search_artists.py
+++ b/examples/search_artists.py
@@ -3,7 +3,7 @@ import asyncio
 from shazamio import Serialize, Shazam
 
 
-async def main():
+async def main() -> None:
     shazam = Shazam()
     artists = await shazam.search_artist(query="LIL", limit=5)
     for artist in artists["artists"]["hits"]:

--- a/examples/search_tracks.py
+++ b/examples/search_tracks.py
@@ -3,7 +3,7 @@ import asyncio
 from shazamio import Shazam
 
 
-async def main():
+async def main() -> None:
     shazam = Shazam()
     tracks = await shazam.search_track(query="Lil", limit=5)
     print(tracks)

--- a/examples/song_listening_counter.py
+++ b/examples/song_listening_counter.py
@@ -3,7 +3,7 @@ import asyncio
 from shazamio import Shazam
 
 
-async def main():
+async def main() -> None:
     # Example: https://www.shazam.com/track/559284007/rampampam
 
     shazam = Shazam()

--- a/examples/top_artist_tracks.py
+++ b/examples/top_artist_tracks.py
@@ -6,7 +6,7 @@ from shazamio.schemas.artists import ArtistQuery
 from shazamio.schemas.enums import ArtistView
 
 
-async def main():
+async def main() -> None:
     shazam = Shazam()
     artist_id = 1081606072
 

--- a/examples/top_tracks_city.py
+++ b/examples/top_tracks_city.py
@@ -3,7 +3,7 @@ import asyncio
 from shazamio import Serialize, Shazam
 
 
-async def main():
+async def main() -> None:
     shazam = Shazam(language="EN")
     top_ten_moscow_tracks = await shazam.top_city_tracks(
         country_code="RU",

--- a/examples/top_tracks_country.py
+++ b/examples/top_tracks_country.py
@@ -3,7 +3,7 @@ import asyncio
 from shazamio import Serialize, Shazam
 
 
-async def main():
+async def main() -> None:
     shazam = Shazam()
     top_five_track_from_amsterdam = await shazam.top_country_tracks("NL", 100)
     tracks = Serialize.playlists(top_five_track_from_amsterdam)

--- a/examples/top_tracks_genre_country.py
+++ b/examples/top_tracks_genre_country.py
@@ -3,7 +3,7 @@ import asyncio
 from shazamio import GenreMusic, Serialize, Shazam
 
 
-async def main():
+async def main() -> None:
     shazam = Shazam()
     top_spain_rap = await shazam.top_country_genre_tracks(
         country_code="ES",

--- a/examples/top_tracks_genre_world.py
+++ b/examples/top_tracks_genre_world.py
@@ -3,7 +3,7 @@ import asyncio
 from shazamio import GenreMusic, Serialize, Shazam
 
 
-async def main():
+async def main() -> None:
     shazam = Shazam()
     top_rock_in_the_world = await shazam.top_world_genre_tracks(genre=GenreMusic.ROCK, limit=10)
 

--- a/examples/top_world_tracks.py
+++ b/examples/top_world_tracks.py
@@ -3,7 +3,7 @@ import asyncio
 from shazamio import Serialize, Shazam
 
 
-async def main():
+async def main() -> None:
     shazam = Shazam()
     top_world_tracks = await shazam.top_world_tracks(limit=10)
     serialized = Serialize.playlists(top_world_tracks)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,13 +125,19 @@ ignore = [
     #  `LICENSE` covers everything.
     "CPY001",
 
-    # The tree predates any docstring or annotation convention: documenting and
-    #  typing the public surface is its own effort, and turning these on now
-    #  would bury real findings under hundreds of legacy ones.
+    # The tree predates any docstring convention and there are 250 undocumented
+    #  public names; writing them is its own effort, and turning this on now
+    #  would bury real findings under legacy ones.
     "D1",      # Undocumented public module/class/method/function
     "D205",    # Legacy docstrings have no summary-line structure to enforce
     "D401",    # Same: rewording legacy docstrings is not lint's job
-    "ANN",     # Missing annotations
+
+    # `Any` is the honest annotation in all 11 places this fires: the generic
+    #  `RingBuffer`, the `**kwargs` both HTTP clients forward to `aiohttp`, the
+    #  argument-forwarding deprecation decorator, pydantic's own
+    #  `model_post_init(self, _context: Any)` hook, and `validate_json`, which
+    #  returns whatever the endpoint sent. The rest of `ANN` is enforced.
+    "ANN401",  # `Any` in an argument or return annotation
 
     # Public exception classes have carried these names since 0.0.x; renaming
     #  them to `*Error` is a breaking change, not a lint fix.

--- a/shazamio/__init__.py
+++ b/shazamio/__init__.py
@@ -4,9 +4,18 @@ from .api import Shazam
 from .client import HTTPClient
 from .converter import GeoService
 from .enums import GenreMusic
+
+# `BadMethod` and `BadParseData` stay in `shazamio.exceptions`: they report an
+#  internal invariant rather than something the caller passed in, so nothing
+#  outside the package has a reason to catch them.
+from .exceptions import BadCityName, BadCountryName, BadRegionName, FailedDecodeJson
 from .serializers import Serialize
 
 __all__ = (
+    "BadCityName",
+    "BadCountryName",
+    "BadRegionName",
+    "FailedDecodeJson",
     "GenreMusic",
     "GeoService",
     "HTTPClient",

--- a/shazamio/algorithm.py
+++ b/shazamio/algorithm.py
@@ -10,7 +10,7 @@ HANNING_MATRIX = np.hanning(2050)[1:-1]  # Wipe trailing and leading zeroes
 
 
 class RingBuffer(list):
-    def __init__(self, buffer_size: int, default_value: Any = None):
+    def __init__(self, buffer_size: int, default_value: Any = None) -> None:
         if default_value is not None:
             list.__init__(self, [copy(default_value) for _ in range(buffer_size)])
         else:
@@ -20,7 +20,7 @@ class RingBuffer(list):
         self.buffer_size: int = buffer_size
         self.num_written: int = 0
 
-    def append(self, value: Any):
+    def append(self, value: Any) -> None:
         self[self.position] = value
 
         self.position += 1
@@ -29,7 +29,7 @@ class RingBuffer(list):
 
 
 class SignatureGenerator:
-    def __init__(self):
+    def __init__(self) -> None:
         # Used when storing input that will be processed when requiring to
         # generate a signature:
 
@@ -123,7 +123,7 @@ class SignatureGenerator:
             self.do_fft(s16le_mono_samples[position_of_chunk : position_of_chunk + 128])
             self.do_peak_spreading_and_recognition()
 
-    def do_fft(self, batch_of_128_s16le_mono_samples):
+    def do_fft(self, batch_of_128_s16le_mono_samples: list[int]) -> None:
         type_ring = self.ring_buffer_of_samples.position + len(batch_of_128_s16le_mono_samples)
         self.ring_buffer_of_samples[self.ring_buffer_of_samples.position : type_ring] = (
             batch_of_128_s16le_mono_samples
@@ -147,12 +147,12 @@ class SignatureGenerator:
 
         self.fft_outputs.append(fft_results)
 
-    def do_peak_spreading_and_recognition(self):
+    def do_peak_spreading_and_recognition(self) -> None:
         self.do_peak_spreading()
         if self.spread_fft_output.num_written >= 46:
             self.do_peak_recognition()
 
-    def do_peak_spreading(self):
+    def do_peak_spreading(self) -> None:
         origin_last_fft: list[float] = self.fft_outputs[self.fft_outputs.position - 1]
 
         temporary_array_1 = np.tile(origin_last_fft, 3).reshape((3, -1))

--- a/shazamio/api.py
+++ b/shazamio/api.py
@@ -30,7 +30,7 @@ class Shazam(Request):
         endpoint_country: str = "GB",
         http_client: HTTPClientInterface | None = None,
         segment_duration_seconds: int = 10,
-    ):
+    ) -> None:
         super().__init__(language=language)
 
         self.core_recognizer = Recognizer(
@@ -433,7 +433,7 @@ class Shazam(Request):
         limit: int = 10,
         offset: int = 0,
         proxy: str | None = None,
-    ):
+    ) -> dict[str, Any]:
         """Get all albums of a specific artist.
 
         :param artist_id: Artist number. Example (203347991)
@@ -461,7 +461,7 @@ class Shazam(Request):
         self,
         album_id: int,
         proxy: str | None = None,
-    ):
+    ) -> dict[str, Any]:
         """Get album info by id.
 
         :param album_id: Album number. Example (203347991)

--- a/shazamio/client.py
+++ b/shazamio/client.py
@@ -38,8 +38,8 @@ class HTTPClient(HTTPClientInterface):
         self,
         method: str,
         url: str,
-        *args,
-        **kwargs,
+        *args: str,
+        **kwargs: Any,
     ) -> list[Any] | dict[str, Any]:
         async with RetryClient(
             retry_options=self.retry_options,

--- a/shazamio/converter.py
+++ b/shazamio/converter.py
@@ -11,7 +11,7 @@ from shazamio.typehints import CountryCode
 
 
 class GeoService:
-    def __init__(self, client: HTTPClientInterface):
+    def __init__(self, client: HTTPClientInterface) -> None:
         self.client = client
 
     async def get_country_playlist(self, country: CountryCode) -> str:

--- a/shazamio/interfaces/client.py
+++ b/shazamio/interfaces/client.py
@@ -8,7 +8,7 @@ class HTTPClientInterface(ABC):
         self,
         method: str,
         url: str,
-        *args,
-        **kwargs,
+        *args: str,
+        **kwargs: Any,
     ) -> list[Any] | dict[str, Any]:
         raise NotImplementedError

--- a/shazamio/misc.py
+++ b/shazamio/misc.py
@@ -50,10 +50,10 @@ class ShazamUrl:
 class Request:
     TIME_ZONE = "Europe/Moscow"
 
-    def __init__(self, language: str):
+    def __init__(self, language: str) -> None:
         self.language = language
 
-    def headers(self):
+    def headers(self) -> dict[str, str]:
         return {
             "X-Shazam-Platform": "IPHONE",
             "X-Shazam-AppVersion": "14.1.0",

--- a/shazamio/signature.py
+++ b/shazamio/signature.py
@@ -50,7 +50,7 @@ class FrequencyPeak:
         peak_magnitude: int,
         corrected_peak_frequency_bin: int,
         sample_rate_hz: int,
-    ):
+    ) -> None:
         self.fft_pass_number = fft_pass_number
         self.peak_magnitude = peak_magnitude
         self.corrected_peak_frequency_bin = corrected_peak_frequency_bin
@@ -82,7 +82,7 @@ class DecodedMessage:
     frequency_band_to_sound_peaks: dict[FrequencyBand, list[FrequencyPeak]] = None
 
     @classmethod
-    def decode_from_binary(cls, data: bytes):
+    def decode_from_binary(cls, data: bytes) -> "DecodedMessage":
         self = cls()
 
         buf = BytesIO(data)

--- a/shazamio/utils.py
+++ b/shazamio/utils.py
@@ -1,7 +1,7 @@
 import pathlib
 from enum import Enum
 from io import BytesIO
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
 import aiofiles
 import aiohttp
@@ -15,7 +15,10 @@ SongT: TypeAlias = str | pathlib.Path | bytes | bytearray
 FileT: TypeAlias = str | pathlib.Path
 
 
-async def validate_json(resp: aiohttp.ClientResponse, content_type: str = "application/json"):
+async def validate_json(
+    resp: aiohttp.ClientResponse,
+    content_type: str = "application/json",
+) -> Any:
     try:
         return await resp.json(content_type=content_type)
     except ContentTypeError as er:
@@ -48,7 +51,7 @@ class QueryBuilder:
     def __init__(
         self,
         source: list[str | Enum],
-    ):
+    ) -> None:
         self.source = source
 
     def to_str(self) -> str:
@@ -59,7 +62,7 @@ class ArtistQueryGenerator:
     def __init__(
         self,
         source: ArtistQuery | None = None,
-    ):
+    ) -> None:
         self.source = source
 
     def params(self) -> dict[str, str]:

--- a/tests/test_21_issue.py
+++ b/tests/test_21_issue.py
@@ -1,3 +1,6 @@
+from collections.abc import Iterator
+from typing import Any
+
 import pytest
 import pytest_asyncio
 
@@ -5,7 +8,7 @@ from shazamio import Serialize
 
 
 @pytest_asyncio.fixture(scope="session")
-def song_response():
+def song_response() -> Iterator[dict[str, Any]]:
     response = {
         "matches": [
             {
@@ -252,6 +255,6 @@ def song_response():
 
 
 @pytest.mark.asyncio
-async def test_recognize_song_bug(song_response: bytes):
+async def test_recognize_song_bug(song_response: dict[str, Any]) -> None:
     serialize_out = Serialize.full_track(data=song_response)
     assert serialize_out.matches[0].channel is None

--- a/tests/test_get_next_signature.py
+++ b/tests/test_get_next_signature.py
@@ -7,18 +7,18 @@ from shazamio.signature import DecodedMessage
 
 
 @pytest.fixture
-def signature_instance():
+def signature_instance() -> SignatureGenerator:
     instance = SignatureGenerator()
     instance.input_pending_processing = [random.randint(-32768, 32767) for _ in range(128 * 2)]
     return instance
 
 
-def test_no_samples_to_process(signature_instance):
+def test_no_samples_to_process(signature_instance: SignatureGenerator) -> None:
     signature_instance.samples_processed = len(signature_instance.input_pending_processing)
     result = signature_instance.get_next_signature()
     assert result is None
 
 
-def test_successful_signature_extraction(signature_instance):
+def test_successful_signature_extraction(signature_instance: SignatureGenerator) -> None:
     result = signature_instance.get_next_signature()
     assert isinstance(result, DecodedMessage)

--- a/tests/test_peak_spreading_numpy.py
+++ b/tests/test_peak_spreading_numpy.py
@@ -6,7 +6,7 @@ from pydub import AudioSegment
 from shazamio.algorithm import SignatureGenerator
 
 
-def do_peak_spreading_non_numpy(self):
+def do_peak_spreading_non_numpy(self: SignatureGenerator) -> None:
     origin_last_fft: list[float] = self.fft_outputs[self.fft_outputs.position - 1]
 
     spread_last_fft: list[float] = list(origin_last_fft)
@@ -35,7 +35,7 @@ def do_peak_spreading_non_numpy(self):
 
 
 @pytest.mark.asyncio
-async def test_do_peak_spreading_numpy():
+async def test_do_peak_spreading_numpy() -> None:
     audio = AudioSegment.from_file(file="examples/data/dora.ogg")
 
     audio = audio.set_sample_width(2)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,5 +1,33 @@
 import importlib.resources
+from typing import Final
+
+import shazamio
+
+# What the package promises to keep working. Removing a name from here is a
+#  breaking change for anyone importing it, so it takes two deliberate edits.
+_EXPORTS: Final[tuple[str, ...]] = (
+    "BadCityName",
+    "BadCountryName",
+    "BadRegionName",
+    "FailedDecodeJson",
+    "GenreMusic",
+    "GeoService",
+    "HTTPClient",
+    "SearchParams",
+    "Serialize",
+    "Shazam",
+)
 
 
 def test_the_installed_package_carries_the_typing_marker() -> None:
     assert importlib.resources.files("shazamio").joinpath("py.typed").is_file()
+
+
+def test_the_package_exports_exactly_the_documented_surface() -> None:
+    assert shazamio.__all__ == _EXPORTS
+
+
+def test_every_exported_name_resolves() -> None:
+    unresolvable = [name for name in shazamio.__all__ if not hasattr(shazamio, name)]
+
+    assert unresolvable == []

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,5 @@
+import importlib.resources
+
+
+def test_the_installed_package_carries_the_typing_marker() -> None:
+    assert importlib.resources.files("shazamio").joinpath("py.typed").is_file()

--- a/tests/test_recognize.py
+++ b/tests/test_recognize.py
@@ -1,3 +1,4 @@
+from collections.abc import AsyncIterator
 from io import BytesIO
 
 import pytest
@@ -9,13 +10,13 @@ from shazamio.utils import get_file_bytes
 
 
 @pytest_asyncio.fixture(scope="session")
-async def song_bytes():
+async def song_bytes() -> AsyncIterator[bytes]:
     bytes_data = await get_file_bytes(file="examples/data/Gloria.ogg")
     yield bytes_data
 
 
 @pytest.mark.asyncio
-async def test_recognize_song_file():
+async def test_recognize_song_file() -> None:
     shazam = Shazam()
     out = await shazam.recognize(data="examples/data/Gloria.ogg")
     assert out.get("matches") != []
@@ -23,7 +24,7 @@ async def test_recognize_song_file():
 
 
 @pytest.mark.asyncio
-async def test_recognize_song_bytes(song_bytes: bytes):
+async def test_recognize_song_bytes(song_bytes: bytes) -> None:
     shazam = Shazam()
     out = await shazam.recognize(data=song_bytes)
     assert out.get("matches") != []
@@ -31,7 +32,7 @@ async def test_recognize_song_bytes(song_bytes: bytes):
 
 
 @pytest.mark.asyncio
-async def test_recognize_song_too_short():
+async def test_recognize_song_too_short() -> None:
     short_audio_segment = AudioSegment.from_file(
         file=BytesIO(b"0" * 126),
         format="pcm",


### PR DESCRIPTION
## What

Three changes to one surface: what the package exports, whether those exports carry
types, and whether the annotations are enforced.

**The caller-facing exceptions are exported from the package root.** Anyone catching
`BadCityName` had to reach into `shazamio.exceptions`, which is not a documented
module:

    >>> import shazamio, importlib.resources
    >>> shazamio.__all__
    ('GenreMusic', 'GeoService', 'HTTPClient', 'SearchParams', 'Serialize', 'Shazam')
    >>> shazamio.BadCityName
    AttributeError: module 'shazamio' has no attribute 'BadCityName'
    >>> importlib.resources.files("shazamio").joinpath("py.typed").is_file()
    False

    >>> shazamio.__all__
    ('BadCityName', 'BadCountryName', 'BadRegionName', 'FailedDecodeJson',
     'GenreMusic', 'GeoService', 'HTTPClient', 'SearchParams', 'Serialize', 'Shazam')
    >>> shazamio.BadCityName
    <class 'shazamio.exceptions.BadCityName'>
    >>> importlib.resources.files("shazamio").joinpath("py.typed").is_file()
    True

`BadMethod` and `BadParseData` stay in `shazamio.exceptions`: both report an internal
invariant rather than something the caller passed in, so nothing outside the package
has a reason to catch them. `tests/test_public_api.py` pins the list, so dropping a
name from it takes two deliberate edits.

**`py.typed` is what makes the annotations visible to consumers.** Without the marker
a type checker treats the whole package as untyped and every annotation below is
discarded. `uv_build` picks it up with no `pyproject.toml` change, since
`module-root = ""` already ships the package directory whole.

**`ANN` was ignored wholesale and is now enforced**, with `ANN401` the only carve-out:

    $ uv run ruff check --select ANN --ignore ANN401 .
    Found 53 errors.        # before

    $ uv run ruff check --select ANN --ignore ANN401 .
    All checks passed!      # after

The 53 are return types on `__init__` and the DSP methods, the two `Shazam` methods
that had no return annotation while their 17 siblings did, the `*args` / `**kwargs`
of the HTTP client, and `-> None` on the examples. One existing annotation was
wrong rather than missing: `test_recognize_song_bug` declared its fixture `bytes`
where the fixture yields a `dict`.

`ANN401` stays ignored in the 11 places `Any` is the honest answer, listed with the
reason in `pyproject.toml`.

**What this does not fix:** 17 of the 20 `Shazam` methods still return
`dict[str, Any]`, so the pydantic models never reach the public return path and a
consumer's type checker learns almost nothing about a response. `py.typed` is what
makes narrowing those returns worth doing; it does not do it.

## How to test

    just lint
    just test
    uv build --wheel && unzip -l dist/shazamio-*.whl | grep py.typed
