### PR TITLE
fix(api): point `track_about` at a host that still serves `discovery/v5`

### DIFF
--- a/shazamio/misc.py
+++ b/shazamio/misc.py
@@ -10,9 +10,12 @@ class ShazamUrl:
         "/{uuid_1}/{uuid_2}?sync=true&webv3=true&sampling=true"
         "&connected=&shazamapiversion=v3&sharehub=true&hubv5minorversion=v5.1&hidelb=true&video=v3"
     )
+    # `discovery/v5` answers on `amp.` and `cdn.` only. On `www.` it returns the
+    #  1.7MB single-page-app shell as `text/html`, which surfaces as
+    #  `FailedDecodeJson` and reads like a parsing bug.
     ABOUT_TRACK = (
-        "https://www.shazam.com/discovery/v5/{language}/{endpoint_country}/web/-/track"
-        "/{track_id}?shazamapiversion=v3&video=v3 "
+        "https://amp.shazam.com/discovery/v5/{language}/{endpoint_country}/web/-/track"
+        "/{track_id}?shazamapiversion=v3&video=v3"
     )
     TOP_TRACKS_PLAYLIST = (
         "https://www.shazam.com/services/amapi/v1/catalog/{endpoint_country}"


### PR DESCRIPTION
## What

`track_about` has been raising `FailedDecodeJson` for every track id. The constant
pointed at `www.shazam.com`, which does not serve `discovery/v5` — it answers the
request with the site's single-page-app shell (`200`, `text/html`, 1.7MB), so the
JSON decode fails and the error reads like a parser bug:

    >>> await Shazam().track_about(track_id=549679333)
    shazamio.exceptions.FailedDecodeJson: Failed to decode json (status=200): <!DOCTYPE html><html lang="en-us">...

`amp.shazam.com` still serves it, and is the host `recognize` already uses for the
same API version:

    >>> track = await Shazam().track_about(track_id=549679333)
    >>> track["key"], track["title"], track["subtitle"]
    ('549679333', 'Втюрилась (Новогодняя версия)', 'Dora')

The URL also carried a trailing space after `video=v3`, which `aiohttp` percent-encoded
into the query as `video=v3+`. Removed with the host change.

Probed all three hosts across three user-agent families before picking one:
`discovery/v5` answers on `amp.` and `cdn.` and never on `www.`, whatever agent is
sent. `amp.` over `cdn.` because it is the host the recognition call already uses,
so the two `discovery/v5` constants stay on one origin and can share a connection.

**What this does not fix:** eight of the twelve `ShazamUrl` constants are still dead,
in two distinct ways. Four services are retired and answer `404` with the body
`Not supported` (`search/v3`, `search/v4`, `count/v2`). Four are blocked at the edge
with `405` (`amapi/v1`), which fronts an API that is still there. The methods behind
them still fail, and repairing them is a larger change than a host swap.

## How to test

    just lint
    just test

Then, against the live API:

    uv run python -c "
    import asyncio
    from shazamio import Shazam
    print(asyncio.run(Shazam().track_about(track_id=549679333))['title'])
    "
